### PR TITLE
Eliminate duplicate trail tracking and scatter-shot wave detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1703,9 +1703,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1723,9 +1720,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1743,9 +1737,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1763,9 +1754,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2423,9 +2411,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2443,9 +2428,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2463,9 +2445,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2483,9 +2462,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2503,9 +2479,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2523,9 +2496,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2543,9 +2513,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2563,9 +2530,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2583,9 +2547,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2609,9 +2570,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2635,9 +2593,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2661,9 +2616,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2687,9 +2639,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2713,9 +2662,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2739,9 +2685,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2765,9 +2708,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3073,9 +3013,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3093,9 +3030,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3113,9 +3047,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3133,9 +3064,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3153,9 +3081,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3173,9 +3098,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3485,9 +3407,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3502,9 +3421,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3519,9 +3435,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3536,9 +3449,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3553,9 +3463,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3570,9 +3477,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3587,9 +3491,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3604,9 +3505,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3621,9 +3519,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3638,9 +3533,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3655,9 +3547,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3672,9 +3561,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3689,9 +3575,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5771,9 +5654,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5795,9 +5675,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5819,9 +5696,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5843,9 +5717,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/doppler-effect/model/DopplerEffectModel.ts
+++ b/src/doppler-effect/model/DopplerEffectModel.ts
@@ -23,10 +23,9 @@ import {
   SCALE,
   SOUND_DATA,
   TIME_SPEED,
-  TRAIL,
   type WaveformPoint,
 } from "./DopplerEffectConstants";
-import { MovableObject } from "./MovableObject";
+import { MovableObject, type PositionHistoryPoint } from "./MovableObject";
 import { WaveformManager } from "./WaveformManager";
 import { WaveGenerator } from "./WaveGenerator";
 
@@ -46,11 +45,8 @@ export type WaveDetection = {
   detectionTime: number;
 };
 
-// Position history points type
-export type PositionHistoryPoint = {
-  position: Vector2;
-  timestamp: number;
-};
+// Position history points type — canonical definition lives in MovableObject.ts
+export type { PositionHistoryPoint } from "./MovableObject";
 
 // Simulation state history type for time reversal
 export type SimulationState = {
@@ -106,6 +102,79 @@ export class Scenario extends EnumerationValue {
   public static readonly enumeration = new Enumeration(Scenario);
 }
 
+type ScenarioConfig = {
+  readonly sourceVelocity: Vector2;
+  readonly observerVelocity: Vector2;
+  readonly sourceMoving: boolean;
+  readonly observerMoving: boolean;
+};
+
+const SCENARIO_CONFIGS = new Map<Scenario, ScenarioConfig>([
+  [
+    Scenario.FREE_PLAY,
+    {
+      sourceVelocity: new Vector2(0, 0),
+      observerVelocity: new Vector2(0, 0),
+      sourceMoving: false,
+      observerMoving: false,
+    },
+  ],
+  [
+    Scenario.SOURCE_APPROACHING,
+    {
+      sourceVelocity: new Vector2(100, 0),
+      observerVelocity: new Vector2(0, 0),
+      sourceMoving: true,
+      observerMoving: false,
+    },
+  ],
+  [
+    Scenario.SOURCE_RECEDING,
+    {
+      sourceVelocity: new Vector2(-100, 0),
+      observerVelocity: new Vector2(0, 0),
+      sourceMoving: true,
+      observerMoving: false,
+    },
+  ],
+  [
+    Scenario.OBSERVER_APPROACHING,
+    {
+      sourceVelocity: new Vector2(0, 0),
+      observerVelocity: new Vector2(-100, 0),
+      sourceMoving: false,
+      observerMoving: true,
+    },
+  ],
+  [
+    Scenario.OBSERVER_RECEDING,
+    {
+      sourceVelocity: new Vector2(0, 0),
+      observerVelocity: new Vector2(100, 0),
+      sourceMoving: false,
+      observerMoving: true,
+    },
+  ],
+  [
+    Scenario.SAME_DIRECTION,
+    {
+      sourceVelocity: new Vector2(100, 0),
+      observerVelocity: new Vector2(100, 0),
+      sourceMoving: true,
+      observerMoving: true,
+    },
+  ],
+  [
+    Scenario.PERPENDICULAR,
+    {
+      sourceVelocity: new Vector2(0, 100),
+      observerVelocity: new Vector2(0, 0),
+      sourceMoving: true,
+      observerMoving: false,
+    },
+  ],
+]);
+
 /**
  * Model for the Doppler Effect simulation
  *
@@ -124,8 +193,6 @@ export class DopplerEffectModel {
   // Microphone properties
   public readonly microphonePositionProperty: Property<Vector2>; // Vector2 position of microphone
   public readonly microphoneEnabledProperty: BooleanProperty; // Whether microphone is enabled
-  private lastWaveDetectionTime: number = 0; // Time of last wave detection
-  private readonly waveDetectionCooldown: number = 0.01; // Cooldown between detections (s)
   public readonly waveDetectedProperty: BooleanProperty; // Emits when a wave is detected
 
   // Source and observer objects
@@ -142,11 +209,6 @@ export class DopplerEffectModel {
 
   // Distance between source and observer
   public readonly sourceObserverDistanceProperty: TReadOnlyProperty<number>;
-
-  // Position history for trails
-  private sourcePositionHistory: PositionHistoryPoint[] = [];
-  private observerPositionHistory: PositionHistoryPoint[] = [];
-  private lastTrailSampleTime: number = 0;
 
   // Simulation state properties
   public readonly simulationTimeProperty: NumberProperty; // in seconds (s)
@@ -184,11 +246,11 @@ export class DopplerEffectModel {
 
   // Expose position history for view access
   public get sourceTrail(): PositionHistoryPoint[] {
-    return this.sourcePositionHistory;
+    return this.source.getTrailPoints();
   }
 
   public get observerTrail(): PositionHistoryPoint[] {
-    return this.observerPositionHistory;
+    return this.observer.getTrailPoints();
   }
 
   // Waveform update counter
@@ -291,9 +353,8 @@ export class DopplerEffectModel {
       this.microphoneEnabledProperty.value = this.preferences.microphoneEnabledProperty.value;
     }
     this.waveDetectedProperty.value = false;
-    this.lastWaveDetectionTime = 0;
 
-    // Reset source and observer
+    // Reset source and observer (also clears their trail history)
     this.source.reset(INITIAL_POSITIONS.SOURCE);
     this.observer.reset(INITIAL_POSITIONS.OBSERVER);
 
@@ -301,10 +362,6 @@ export class DopplerEffectModel {
     this.sourceVelocityProperty.reset();
     this.observerVelocityProperty.reset();
 
-    // Clear position history
-    this.sourcePositionHistory = [];
-    this.observerPositionHistory = [];
-    this.lastTrailSampleTime = 0;
     this.waveformUpdateCounter = 0;
 
     // Clear simulation state history
@@ -349,25 +406,23 @@ export class DopplerEffectModel {
 
     // Update simulation time
     this.simulationTimeProperty.value += modelDt; // in seconds (s)
+    const currentTime = this.simulationTimeProperty.value;
 
     // Store simulation state for time reversal
     this.storeSimulationState();
 
-    // Update positions
-    this.source.updatePosition(modelDt);
-    this.observer.updatePosition(modelDt);
-
-    // Record position history for trails
-    this.updatePositionHistory();
+    // Update positions (also records trail history internally)
+    this.source.updatePosition(modelDt, currentTime);
+    this.observer.updatePosition(modelDt, currentTime);
 
     // Generate and update waves
     this.waveGenerator.generateWaves();
-    this.waveGenerator.updateWaves(this.simulationTimeProperty.value, modelDt);
+    this.waveGenerator.updateWaves(currentTime, modelDt);
 
     // Check for waves at microphone
-    if (this.microphoneEnabledProperty.value) {
-      this.detectWavesAtMicrophone();
-    }
+    this.waveDetectedProperty.value =
+      this.microphoneEnabledProperty.value &&
+      this.waveGenerator.detectWaveAt(this.microphonePositionProperty.value, currentTime);
 
     // Calculate Doppler effect and update waveforms
     this.updateWaveforms(modelDt);
@@ -474,59 +529,6 @@ export class DopplerEffectModel {
   }
 
   /**
-   * Update position history for source and observer
-   * This method records positions at regular intervals and maintains a fixed-size history
-   */
-  private updatePositionHistory(): void {
-    const currentTime = this.simulationTimeProperty.value;
-
-    // Only sample at specified intervals
-    if (currentTime - this.lastTrailSampleTime >= TRAIL.SAMPLE_INTERVAL) {
-      // Record source position
-      this.sourcePositionHistory.push({
-        position: this.sourcePositionProperty.value.copy(),
-        timestamp: currentTime,
-      });
-
-      // Record observer position
-      this.observerPositionHistory.push({
-        position: this.observerPositionProperty.value.copy(),
-        timestamp: currentTime,
-      });
-
-      // Update last sample time
-      this.lastTrailSampleTime = currentTime;
-
-      // Remove old positions based on age
-      this.prunePositionHistory();
-    }
-  }
-
-  /**
-   * Remove old positions from history that exceed the maximum age or count
-   */
-  private prunePositionHistory(): void {
-    const currentTime = this.simulationTimeProperty.value;
-    const maxAge = currentTime - TRAIL.MAX_AGE;
-
-    // Prune source trail
-    while (
-      this.sourcePositionHistory.length > TRAIL.MAX_POINTS ||
-      (this.sourcePositionHistory[0] !== undefined && this.sourcePositionHistory[0].timestamp < maxAge)
-    ) {
-      this.sourcePositionHistory.shift();
-    }
-
-    // Prune observer trail
-    while (
-      this.observerPositionHistory.length > TRAIL.MAX_POINTS ||
-      (this.observerPositionHistory[0] !== undefined && this.observerPositionHistory[0].timestamp < maxAge)
-    ) {
-      this.observerPositionHistory.shift();
-    }
-  }
-
-  /**
    * Update waveforms and calculate Doppler effect
    * @param dt Elapsed model time in seconds (s)
    */
@@ -607,67 +609,13 @@ export class DopplerEffectModel {
 
   /**
    * Configure velocity settings for a specific scenario
-   * @param scenario - the scenario to configure
-   * @private
    */
   private configureScenarioVelocities(scenario: Scenario): void {
-    switch (scenario) {
-      case Scenario.SOURCE_APPROACHING:
-        // Source moves toward a stationary observer
-        this.sourceVelocityProperty.value = new Vector2(100, 0); // Positive x = moving right (toward observer)
-        this.observerVelocityProperty.value = new Vector2(0, 0);
-        this.sourceMovingProperty.value = true;
-        this.observerMovingProperty.value = false;
-        break;
-
-      case Scenario.SOURCE_RECEDING:
-        // Source moves away from a stationary observer
-        this.sourceVelocityProperty.value = new Vector2(-100, 0); // Negative x = moving left (away from observer)
-        this.observerVelocityProperty.value = new Vector2(0, 0);
-        this.sourceMovingProperty.value = true;
-        this.observerMovingProperty.value = false;
-        break;
-
-      case Scenario.OBSERVER_APPROACHING:
-        // Observer moves toward a stationary source
-        this.sourceVelocityProperty.value = new Vector2(0, 0);
-        this.observerVelocityProperty.value = new Vector2(-100, 0);
-        this.sourceMovingProperty.value = false;
-        this.observerMovingProperty.value = true;
-        break;
-
-      case Scenario.OBSERVER_RECEDING:
-        // Observer moves away from a stationary source
-        this.sourceVelocityProperty.value = new Vector2(0, 0);
-        this.observerVelocityProperty.value = new Vector2(100, 0);
-        this.sourceMovingProperty.value = false;
-        this.observerMovingProperty.value = true;
-        break;
-
-      case Scenario.SAME_DIRECTION:
-        // Both source and observer moving in the same direction at same speed
-        this.sourceVelocityProperty.value = new Vector2(100, 0);
-        this.observerVelocityProperty.value = new Vector2(100, 0);
-        this.sourceMovingProperty.value = true;
-        this.observerMovingProperty.value = true;
-        break;
-
-      case Scenario.PERPENDICULAR:
-        // Source moving perpendicular to the line connecting with observer
-        this.sourceVelocityProperty.value = new Vector2(0, 100);
-        this.observerVelocityProperty.value = new Vector2(0, 0);
-        this.sourceMovingProperty.value = true;
-        this.observerMovingProperty.value = false;
-        break;
-
-      default:
-        // Free play mode - no initial velocities
-        this.sourceVelocityProperty.value = new Vector2(0, 0);
-        this.observerVelocityProperty.value = new Vector2(0, 0);
-        this.sourceMovingProperty.value = false;
-        this.observerMovingProperty.value = false;
-        break;
-    }
+    const config = SCENARIO_CONFIGS.get(scenario) ?? SCENARIO_CONFIGS.get(Scenario.FREE_PLAY)!;
+    this.sourceVelocityProperty.value = config.sourceVelocity.copy();
+    this.observerVelocityProperty.value = config.observerVelocity.copy();
+    this.sourceMovingProperty.value = config.sourceMoving;
+    this.observerMovingProperty.value = config.observerMoving;
   }
 
   /**
@@ -688,41 +636,6 @@ export class DopplerEffectModel {
 
     // Configure velocities for the specific scenario
     this.configureScenarioVelocities(scenario);
-  }
-
-  /**
-   * Detect waves crossing the microphone position
-   */
-  private detectWavesAtMicrophone(): void {
-    const currentTime = this.simulationTimeProperty.value;
-
-    // Skip if we're still in cooldown
-    if (currentTime - this.lastWaveDetectionTime < this.waveDetectionCooldown) {
-      this.waveDetectedProperty.value = false;
-      return;
-    }
-
-    // Reset detection flag
-    this.waveDetectedProperty.value = false;
-
-    // Check all waves - iterating through ObservableArray
-    for (let i = 0; i < this.waves.length; i++) {
-      const wave = this.waves.get(i);
-
-      // Calculate distance from wave center to microphone
-      const distance = this.microphonePositionProperty.value.distance(wave.position);
-
-      // Determine if wave front is crossing the microphone position
-      const waveFrontRadius = wave.radius;
-      const tolerance = 2; // Detection tolerance in meters
-
-      if (Math.abs(distance - waveFrontRadius) < tolerance) {
-        // Wave detected at microphone
-        this.lastWaveDetectionTime = currentTime;
-        this.waveDetectedProperty.value = true;
-        break; // Only detect one wave per frame
-      }
-    }
   }
 
   /**

--- a/src/doppler-effect/model/DopplerEffectModel.ts
+++ b/src/doppler-effect/model/DopplerEffectModel.ts
@@ -611,7 +611,12 @@ export class DopplerEffectModel {
    * Configure velocity settings for a specific scenario
    */
   private configureScenarioVelocities(scenario: Scenario): void {
-    const config = SCENARIO_CONFIGS.get(scenario) ?? SCENARIO_CONFIGS.get(Scenario.FREE_PLAY)!;
+    const config = SCENARIO_CONFIGS.get(scenario) ?? {
+      sourceVelocity: new Vector2(0, 0),
+      observerVelocity: new Vector2(0, 0),
+      sourceMoving: false,
+      observerMoving: false,
+    };
     this.sourceVelocityProperty.value = config.sourceVelocity.copy();
     this.observerVelocityProperty.value = config.observerVelocity.copy();
     this.sourceMovingProperty.value = config.sourceMoving;

--- a/src/doppler-effect/model/MovableObject.ts
+++ b/src/doppler-effect/model/MovableObject.ts
@@ -36,8 +36,9 @@ export class MovableObject {
   /**
    * Update position based on velocity and elapsed time
    * @param dt Elapsed time in seconds (s)
+   * @param currentTime Absolute simulation time in seconds (s)
    */
-  public updatePosition(dt: number): void {
+  public updatePosition(dt: number, currentTime: number): void {
     if (this.movingProperty.value) {
       const position = this.positionProperty.value; // in meters (m)
       const velocity = this.velocityProperty.value; // in meters per second (m/s)
@@ -54,16 +55,14 @@ export class MovableObject {
     }
 
     // Update position history for trail
-    this.updatePositionHistory(dt);
+    this.updatePositionHistory(currentTime);
   }
 
   /**
    * Update position history for trail
-   * @param dt Elapsed time in seconds (s)
+   * @param currentTime Absolute simulation time in seconds (s)
    */
-  private updatePositionHistory(dt: number): void {
-    const currentTime = this.lastTrailSampleTime + dt;
-
+  private updatePositionHistory(currentTime: number): void {
     // Only sample at specified intervals
     if (currentTime - this.lastTrailSampleTime >= TRAIL.SAMPLE_INTERVAL) {
       // Record position

--- a/src/doppler-effect/model/WaveGenerator.ts
+++ b/src/doppler-effect/model/WaveGenerator.ts
@@ -18,6 +18,11 @@ export class WaveGenerator {
   private lastWaveTime: number = 0; // in seconds (s)
   private waveHistory: Wave[] = []; // History of waves for time reversal
 
+  // Microphone detection state
+  private lastDetectionTime: number = 0;
+  private static readonly DETECTION_COOLDOWN = 0.01; // seconds between detections
+  private static readonly DETECTION_TOLERANCE = 2; // meters
+
   /**
    * Create a new WaveGenerator
    */
@@ -94,10 +99,31 @@ export class WaveGenerator {
   }
 
   /**
+   * Detect whether a wave front is currently crossing a given position.
+   * Returns true at most once per DETECTION_COOLDOWN interval.
+   * @param position Position to check in meters (m)
+   * @param currentTime Absolute simulation time in seconds (s)
+   */
+  public detectWaveAt(position: Vector2, currentTime: number): boolean {
+    if (currentTime - this.lastDetectionTime < WaveGenerator.DETECTION_COOLDOWN) {
+      return false;
+    }
+    for (let i = 0; i < this.waves.length; i++) {
+      const wave = this.waves.get(i);
+      if (Math.abs(position.distance(wave.position) - wave.radius) < WaveGenerator.DETECTION_TOLERANCE) {
+        this.lastDetectionTime = currentTime;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Reset the wave generator state
    */
   public reset(): void {
     this.lastWaveTime = 0;
+    this.lastDetectionTime = 0;
     this.waves.clear();
     this.waveHistory = [];
   }


### PR DESCRIPTION
- MovableObject.updatePosition now takes an absolute currentTime so its
  trail sampling uses the same time base as the rest of the simulation
  (the old relative-dt accumulator never fired when dt < SAMPLE_INTERVAL)
- DopplerEffectModel no longer maintains its own sourcePositionHistory /
  observerPositionHistory; sourceTrail / observerTrail delegate to the
  MovableObject instances it already owns
- Wave detection (cooldown + proximity check) moved into WaveGenerator,
  which already owns the waves array; model step reduces to one expression
- Scenario velocity config replaced by a SCENARIO_CONFIGS data map,
  removing a 78-line switch and making new scenarios a one-liner

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>