### PR TITLE
Fix microphone intermittently missing wave fronts

### DIFF
--- a/src/doppler-effect/model/DopplerEffectModel.ts
+++ b/src/doppler-effect/model/DopplerEffectModel.ts
@@ -425,7 +425,7 @@ export class DopplerEffectModel {
     // Check for waves at microphone
     this.waveDetectedProperty.value =
       this.microphoneEnabledProperty.value &&
-      this.waveGenerator.detectWaveAt(this.microphonePositionProperty.value, currentTime);
+      this.waveGenerator.detectWaveAt(this.microphonePositionProperty.value, currentTime, modelDt);
 
     // Calculate Doppler effect and update waveforms
     this.updateWaveforms(modelDt);

--- a/src/doppler-effect/model/WaveGenerator.ts
+++ b/src/doppler-effect/model/WaveGenerator.ts
@@ -99,18 +99,36 @@ export class WaveGenerator {
   }
 
   /**
-   * Detect whether a wave front is currently crossing a given position.
+   * Detect whether a wave front passes through a given position during the current step.
+   *
+   * Rather than checking whether a front is momentarily within a fixed tolerance band
+   * (which a fast-expanding front can step right over between frames — e.g. at 343 m/s
+   * and 60 fps a front advances ~5.7 m per frame, larger than the detection band), this
+   * detects the front *crossing* the position: the front was inside the position last
+   * step (radius < distance) and has reached or passed it this step (radius >= distance).
+   * A small static tolerance is kept as a fallback for the dt ~ 0 case (paused/stepped).
+   *
    * Returns true at most once per DETECTION_COOLDOWN interval.
    * @param position Position to check in meters (m)
    * @param currentTime Absolute simulation time in seconds (s)
+   * @param modelDt Elapsed model time for this step in seconds (s)
    */
-  public detectWaveAt(position: Vector2, currentTime: number): boolean {
+  public detectWaveAt(position: Vector2, currentTime: number, modelDt: number): boolean {
     if (currentTime - this.lastDetectionTime < WaveGenerator.DETECTION_COOLDOWN) {
       return false;
     }
+    // Distance the wave front advanced during this step (meters)
+    const stepAdvance = modelDt * this.getSoundSpeed();
     for (let i = 0; i < this.waves.length; i++) {
       const wave = this.waves.get(i);
-      if (Math.abs(position.distance(wave.position) - wave.radius) < WaveGenerator.DETECTION_TOLERANCE) {
+      const distance = position.distance(wave.position);
+      const previousRadius = wave.radius - stepAdvance;
+      // True if the expanding front swept across the position during this step,
+      // or (fallback) is essentially sitting on it when no time elapsed.
+      if (
+        (previousRadius < distance && distance <= wave.radius) ||
+        Math.abs(distance - wave.radius) < WaveGenerator.DETECTION_TOLERANCE
+      ) {
         this.lastDetectionTime = currentTime;
         return true;
       }

--- a/tests/WaveGenerator.test.ts
+++ b/tests/WaveGenerator.test.ts
@@ -86,6 +86,95 @@ describe("WaveGenerator.generateWaves", () => {
   });
 });
 
+describe("WaveGenerator.detectWaveAt", () => {
+  const soundSpeed = 343;
+  // ~60 fps step: front advances soundSpeed * dt ~= 5.7 m, larger than the
+  // legacy ±2 m detection band — the case that previously failed to detect.
+  const dt = 1 / 60;
+
+  function makeGenerator(waves: ReturnType<typeof makeFakeWaveArray>, time: () => number) {
+    return new WaveGenerator(
+      waves,
+      time,
+      () => new Vector2(0, 0),
+      () => new Vector2(0, 0),
+      () => 10,
+      () => soundSpeed,
+      () => 0,
+    );
+  }
+
+  it("detects a fast-expanding front that steps over the old tolerance band", () => {
+    let time = 0;
+    const waves = makeFakeWaveArray();
+    const generator = makeGenerator(waves, () => time);
+
+    // Wave emitted at origin; microphone 100 m away.
+    const micPosition = new Vector2(100, 0);
+    waves.add({
+      position: new Vector2(0, 0),
+      radius: 0,
+      birthTime: 0,
+      sourceVelocity: new Vector2(0, 0),
+      sourceFrequency: 10,
+      phaseAtEmission: 0,
+    });
+
+    // Advance the front frame by frame; it should be detected on exactly the
+    // frame where it crosses 100 m, never skipping past it.
+    let detected = false;
+    for (let i = 1; i <= 1200; i++) {
+      time = i * dt;
+      waves.get(0).radius += dt * soundSpeed;
+      if (generator.detectWaveAt(micPosition, time, dt)) {
+        detected = true;
+        break;
+      }
+    }
+    expect(detected).toBe(true);
+  });
+
+  it("does not detect before the front reaches the position", () => {
+    const time = 0.1;
+    const waves = makeFakeWaveArray();
+    const generator = makeGenerator(waves, () => time);
+
+    waves.add({
+      position: new Vector2(0, 0),
+      radius: 10, // front at 10 m
+      birthTime: 0,
+      sourceVelocity: new Vector2(0, 0),
+      sourceFrequency: 10,
+      phaseAtEmission: 0,
+    });
+
+    // Microphone well beyond the front and beyond the per-step advance.
+    expect(generator.detectWaveAt(new Vector2(100, 0), time, dt)).toBe(false);
+  });
+
+  it("respects the detection cooldown", () => {
+    let time = 0;
+    const waves = makeFakeWaveArray();
+    const generator = makeGenerator(waves, () => time);
+
+    const micPosition = new Vector2(50, 0);
+    waves.add({
+      position: new Vector2(0, 0),
+      radius: 50, // sitting exactly on the microphone
+      birthTime: 0,
+      sourceVelocity: new Vector2(0, 0),
+      sourceFrequency: 10,
+      phaseAtEmission: 0,
+    });
+
+    time = 0.02; // beyond the 0.01 s cooldown from the initial 0
+    expect(generator.detectWaveAt(micPosition, time, dt)).toBe(true);
+    // Within the 0.01 s cooldown of the previous detection -> suppressed.
+    time = 0.025;
+    expect(generator.detectWaveAt(micPosition, time, dt)).toBe(false);
+  });
+});
+
 describe("WaveGenerator.updateWaves", () => {
   it("expands wave radius by soundSpeed * dt", () => {
     let time = 0;


### PR DESCRIPTION
The microphone detected a wave only when a front was momentarily within a
fixed ±2 m band of it. At the sound speed of 343 m/s, an expanding front
advances ~5.7 m per frame at 60 fps — wider than the 4 m band — so the front
frequently steps over the microphone between frames and is never detected,
producing no click sound. This was only reliable at SLOW time speed.

detectWaveAt now detects the front *crossing* the microphone during a step
(previous radius < distance <= current radius), using the step's modelDt to
know how far the front advanced. The static tolerance is kept as a fallback
for the dt ~ 0 (paused/single-step) case. Added tests covering the fast-front
crossing, the no-detect-before-arrival case, and the cooldown.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LVWd98n2jxyMFC6fDPVvjN