### PR TITLE
Fix interaction and physics bugs found in simulation review

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/doppler-effect/model/WaveGenerator.ts
+++ b/src/doppler-effect/model/WaveGenerator.ts
@@ -51,9 +51,15 @@ export class WaveGenerator {
     const simulationTime = this.getSimulationTime(); // in seconds (s)
     const waveInterval = 1.0 / this.getEmittedFrequency(); // in seconds (s)
 
-    // Check if it's time to emit a new wave
-    if (simulationTime - this.lastWaveTime > waveInterval) {
-      // Create a new wave
+    // Advance the emission clock by whole intervals rather than snapping it to the
+    // current time. Snapping would let each frame's leftover fraction accumulate and
+    // stretch the spacing between waves; stepping by waveInterval keeps the cadence
+    // drift-free and emits every wave whose interval falls inside a long frame.
+    while (simulationTime - this.lastWaveTime > waveInterval) {
+      this.lastWaveTime += waveInterval; // in seconds (s)
+
+      // Create a new wave. Position/velocity/phase are sampled at the current source
+      // state (the emission time is within one interval of now, so this is accurate).
       const newWave = {
         position: this.getSourcePosition().copy(), // in meters (m)
         radius: 0, // in meters (m)
@@ -68,9 +74,6 @@ export class WaveGenerator {
 
       // Store in history for time reversal
       this.waveHistory.push(newWave);
-
-      // Update last wave time (in seconds)
-      this.lastWaveTime = simulationTime; // in seconds (s)
     }
   }
 
@@ -159,9 +162,14 @@ export class WaveGenerator {
       // Only include waves that were born before the target time
       // and haven't exceeded their maximum age
       if (wave.birthTime <= targetTime && targetTime - wave.birthTime <= WAVE.MAX_AGE) {
-        // Create a copy of the wave with the correct radius for the target time
+        // Reconstruct the radius the front had at the target time. This is exact while
+        // the sound speed is constant (radius = age * soundSpeed reduces to the forward
+        // integration in WaveGenerator.updateWaves); if the speed changed during the
+        // wave's lifetime it is a best-effort estimate from the current speed, consistent
+        // with the arrival-time reconstruction in DopplerCalculator.findWavesAtObserver.
+        // age is non-negative here (birthTime <= targetTime), so radius is too.
         const age = targetTime - wave.birthTime;
-        const radius = age * this.getSoundSpeed();
+        const radius = Math.max(0, age * this.getSoundSpeed());
 
         const restoredWave = {
           position: wave.position.copy(),

--- a/src/doppler-effect/view/DopplerEffectScreenView.ts
+++ b/src/doppler-effect/view/DopplerEffectScreenView.ts
@@ -34,7 +34,6 @@ import { DopplerEffectScreenSummaryContent } from "./DopplerEffectScreenSummaryC
 import { DragHandlerManager } from "./managers/DragHandlerManager";
 import { KeyboardHandlerManager } from "./managers/KeyboardHandlerManager";
 import { WaveManager } from "./managers/WaveManager";
-import { Sound } from "./utils/Sound";
 
 // UI constants
 const UI = {
@@ -105,9 +104,6 @@ export class DopplerEffectScreenView extends ScreenView {
   private readonly selectedObjectProperty: Property<"source" | "observer"> = new Property<"source" | "observer">(
     "source",
   );
-
-  // Sound elements
-  private readonly clickSound: Sound;
 
   // Derived property for interface bounds
   private readonly interfaceBoundsProperty: TReadOnlyProperty<Bounds2>;
@@ -234,7 +230,9 @@ export class DopplerEffectScreenView extends ScreenView {
       this.modelViewTransform,
       this.model.microphonePositionProperty,
       this.model.waveDetectedProperty,
-      new Property(this.modelViewTransform.viewToModelBounds(this.layoutBounds)),
+      // Constrain the microphone to the visible model area; follows window resizing
+      // rather than being frozen to the initial layout bounds.
+      modelBoundsProperty,
     );
     this.microphoneNode.setAccessibleName(a11yControls.microphoneStringProperty);
     this.objectLayer.addChild(this.microphoneNode);
@@ -384,7 +382,6 @@ export class DopplerEffectScreenView extends ScreenView {
 
     // Setup keyboard handlers
     this.keyboardManager.attachKeyboardHandlers(
-      this,
       {
         onSourceSelected: () => this.updateSelectionHighlight(),
         onObserverSelected: () => this.updateSelectionHighlight(),
@@ -406,6 +403,8 @@ export class DopplerEffectScreenView extends ScreenView {
       this.model.observerMovingProperty,
       this.model.emittedFrequencyProperty,
       this.model.soundSpeedProperty,
+      this.model.frequencyRange,
+      this.model.soundSpeedRange,
       this.model.microphoneEnabledProperty,
       this.selectedObjectProperty,
       this.model.scenarioProperty,
@@ -433,9 +432,6 @@ export class DopplerEffectScreenView extends ScreenView {
         this.updateSelectionHighlight();
       },
     );
-
-    // Create and load click sound
-    this.clickSound = new Sound("./assets/click.wav", true);
 
     // Setup model listeners
     this.addModelListeners();
@@ -536,12 +532,8 @@ export class DopplerEffectScreenView extends ScreenView {
       this.graphDisplayNode.updateWaveforms(this.model.emittedWaveformData, this.model.observedWaveformData);
     });
 
-    // Listen for wave detection to play click sound
-    this.model.waveDetectedProperty.link((detected) => {
-      if (detected) {
-        this.clickSound.play();
-      }
-    });
+    // Note: the click sound on wave detection is played by MicrophoneNode, which owns
+    // the microphone's detection feedback. Playing it here as well would double the click.
   }
 
   /**

--- a/src/doppler-effect/view/components/MicrophoneNode.ts
+++ b/src/doppler-effect/view/components/MicrophoneNode.ts
@@ -15,6 +15,7 @@ import {
   type Property,
   Rectangle,
   Shape,
+  type TReadOnlyProperty,
   type Vector2,
 } from "scenerystack";
 import { stepTimer } from "scenerystack/axon";
@@ -51,7 +52,7 @@ const MICROPHONE = {
   // colorProperties
   bodyColorProperty: DopplerEffectColors.microphoneBodyColorProperty,
   stemColorProperty: DopplerEffectColors.microphoneStemColorProperty,
-  baseColotProperty: DopplerEffectColors.microphoneBaseColorProperty,
+  baseColorProperty: DopplerEffectColors.microphoneBaseColorProperty,
   gridColorProperty: DopplerEffectColors.microphoneGridColorProperty,
   detectionRingColorProperty: DopplerEffectColors.microphoneDetectionRingColorProperty,
 };
@@ -80,7 +81,7 @@ export class MicrophoneNode extends Node {
     modelViewTransform: ModelViewTransform2,
     microphonePositionProperty: Property<Vector2>,
     waveDetectedProperty: Property<boolean>,
-    dragBoundsProperty: Property<Bounds2>,
+    dragBoundsProperty: TReadOnlyProperty<Bounds2>,
   ) {
     super({
       cursor: "pointer",
@@ -116,7 +117,7 @@ export class MicrophoneNode extends Node {
       MICROPHONE.BASE_WIDTH,
       MICROPHONE.BASE_HEIGHT,
       {
-        fill: MICROPHONE.baseColotProperty,
+        fill: MICROPHONE.baseColorProperty,
         cornerRadius: MICROPHONE.BASE_CORNER_RADIUS,
       },
     );
@@ -156,8 +157,8 @@ export class MicrophoneNode extends Node {
     });
     this.addChild(this.detectionRing);
 
-    // Create and load click sound
-    this.clickSound = new Sound("./assets/click.wav", true);
+    // Create click sound (synthesized via WebAudio; no audio file is loaded)
+    this.clickSound = new Sound("", true);
 
     // Position microphone at initial position
     this.center = this.modelViewTransform.modelToViewPosition(this.microphonePositionProperty.value);

--- a/src/doppler-effect/view/managers/DragHandlerManager.ts
+++ b/src/doppler-effect/view/managers/DragHandlerManager.ts
@@ -84,11 +84,13 @@ export class DragHandlerManager {
 
         // Convert position difference to velocity using a scaling factor
         // This factor represents 1/time and converts distance to distance/time
-        const desiredVelocity = positionDifference.timesScalar(PHYSICS.POSITION_TO_VELOCITY_FACTOR);
+        let desiredVelocity = positionDifference.timesScalar(PHYSICS.POSITION_TO_VELOCITY_FACTOR);
 
-        // Limit velocity to maximum speed
+        // Limit velocity to maximum speed. normalize() mutates in place and timesScalar()
+        // returns a new vector, so the clamped result must be reassigned (otherwise the
+        // velocity collapses to a unit vector instead of being scaled to the max speed).
         if (desiredVelocity.magnitude > this.maxSpeedProperty.value) {
-          desiredVelocity.normalize().timesScalar(this.maxSpeedProperty.value);
+          desiredVelocity = desiredVelocity.normalized().timesScalar(this.maxSpeedProperty.value);
         }
 
         // Apply velocity

--- a/src/doppler-effect/view/managers/KeyboardHandlerManager.ts
+++ b/src/doppler-effect/view/managers/KeyboardHandlerManager.ts
@@ -4,8 +4,24 @@
  * Manages keyboard input handlers for the Doppler Effect simulation.
  */
 
-import { type Node, type Property, type SceneryEvent, Vector2 } from "scenerystack";
+import { type Property, Vector2 } from "scenerystack";
 import { Scenario } from "../../model/DopplerEffectModel";
+
+/** Minimal numeric range shape (satisfied by RangeWithValue). */
+type NumericRange = { min: number; max: number };
+
+/**
+ * Whether keyboard events originating from an editable/text control should be
+ * ignored so that global shortcuts don't fire while the user is typing.
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  if (!element) {
+    return false;
+  }
+  const tag = element.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || element.isContentEditable === true;
+}
 
 /**
  * Callback type for keyboard handling events
@@ -35,10 +51,13 @@ const SCENARIO_BY_KEY: Record<string, Scenario> = {
  * Manager for handling keyboard input
  */
 export class KeyboardHandlerManager {
+  // Stored so the global listener can be removed and re-attachment is idempotent
+  // (attaching twice would otherwise stack duplicate listeners that never get freed).
+  private windowKeydownListener: ((event: KeyboardEvent) => void) | null = null;
+
   /**
    * Attach keyboard event handlers
    *
-   * @param targetNode - Node to attach keyboard listeners to
    * @param callbacks - Callback functions for various keyboard actions
    * @param playProperty - Property for simulation play state
    * @param sourceVelocityProperty - Model property for source velocity
@@ -47,12 +66,13 @@ export class KeyboardHandlerManager {
    * @param observerMovingProperty - Model property for observer moving state
    * @param emittedFrequencyProperty - Model property for emitted frequency
    * @param soundSpeedProperty - Model property for sound speed
+   * @param frequencyRange - Allowed range for the emitted frequency (Hz)
+   * @param soundSpeedRange - Allowed range for the sound speed (m/s)
    * @param microphoneEnabledProperty - Model property for microphone state
    * @param selectedObjectProperty - Property indicating currently selected object
    * @param scenarioProperty - Property for the current scenario
    */
   public attachKeyboardHandlers(
-    targetNode: Node,
     callbacks: KeyboardCallbacks,
     playProperty: Property<boolean>,
     sourceVelocityProperty: Property<Vector2>,
@@ -61,6 +81,8 @@ export class KeyboardHandlerManager {
     observerMovingProperty: Property<boolean>,
     emittedFrequencyProperty: Property<number>,
     soundSpeedProperty: Property<number>,
+    frequencyRange: NumericRange,
+    soundSpeedRange: NumericRange,
     microphoneEnabledProperty: Property<boolean>,
     selectedObjectProperty: Property<"source" | "observer">,
     scenarioProperty: Property<Scenario>,
@@ -84,28 +106,30 @@ export class KeyboardHandlerManager {
 
       this.handleActions(key, callbacks, playProperty, microphoneEnabledProperty);
       this.handleScenarioPresets(key, scenarioProperty);
-      this.handleAdjustments(key, emittedFrequencyProperty, soundSpeedProperty);
+      this.handleAdjustments(key, emittedFrequencyProperty, soundSpeedProperty, frequencyRange, soundSpeedRange);
     };
 
-    // Add key listeners to the view
-    const keydownListener = {
-      listener: (event: SceneryEvent<KeyboardEvent>) => {
-        if (!event.domEvent) {
-          return;
-        }
-        const key = event.domEvent.key.toLowerCase();
-        handleKeydown(key);
-      },
+    // A single global keydown listener drives the sim-wide shortcuts. Re-attaching
+    // removes any previous listener first so handlers can never stack or leak.
+    this.detachKeyboardHandlers();
+    this.windowKeydownListener = (event: KeyboardEvent) => {
+      // Don't hijack keys while the user is typing in an editable control.
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+      handleKeydown(event.key.toLowerCase());
     };
+    window.addEventListener("keydown", this.windowKeydownListener);
+  }
 
-    // Add the keyboard listener to the view
-    targetNode.addInputListener(keydownListener);
-
-    // Also add a global keyboard listener to ensure we catch all keyboard events
-    window.addEventListener("keydown", (event) => {
-      const key = event.key.toLowerCase();
-      handleKeydown(key);
-    });
+  /**
+   * Remove the global keyboard listener, if one is attached.
+   */
+  public detachKeyboardHandlers(): void {
+    if (this.windowKeydownListener) {
+      window.removeEventListener("keydown", this.windowKeydownListener);
+      this.windowKeydownListener = null;
+    }
   }
 
   /**
@@ -144,6 +168,9 @@ export class KeyboardHandlerManager {
     // Set velocity based on key
     const velocity = new Vector2(0, 0);
 
+    // Note: "s" is reserved for selecting the source (see handleObjectSelection),
+    // so downward movement uses ArrowDown only. "w"/"a"/"d" remain as WASD aliases
+    // for the non-conflicting directions.
     if (key === "arrowleft" || key === "a") {
       velocity.x = -100.0;
     } else if (key === "arrowright" || key === "d") {
@@ -152,7 +179,7 @@ export class KeyboardHandlerManager {
 
     if (key === "arrowup" || key === "w") {
       velocity.y = 100.0;
-    } else if (key === "arrowdown" || key === "s") {
+    } else if (key === "arrowdown") {
       velocity.y = -100.0;
     }
 
@@ -200,23 +227,28 @@ export class KeyboardHandlerManager {
   }
 
   /**
-   * Adjust emitted frequency and sound speed
+   * Adjust emitted frequency and sound speed, clamped to the same ranges the
+   * sliders enforce so the keyboard can't drive values out of bounds.
    */
   private handleAdjustments(
     key: string,
     emittedFrequencyProperty: Property<number>,
     soundSpeedProperty: Property<number>,
+    frequencyRange: NumericRange,
+    soundSpeedRange: NumericRange,
   ): void {
+    const clamp = (value: number, range: NumericRange) => Math.max(range.min, Math.min(range.max, value));
+
     if (key === "+" || key === "=") {
-      emittedFrequencyProperty.value += 0.1;
+      emittedFrequencyProperty.value = clamp(emittedFrequencyProperty.value + 0.1, frequencyRange);
     } else if (key === "-" || key === "_") {
-      emittedFrequencyProperty.value = Math.max(0.1, emittedFrequencyProperty.value - 0.1);
+      emittedFrequencyProperty.value = clamp(emittedFrequencyProperty.value - 0.1, frequencyRange);
     }
 
     if (key === "." || key === ">") {
-      soundSpeedProperty.value += 1.0;
+      soundSpeedProperty.value = clamp(soundSpeedProperty.value + 1.0, soundSpeedRange);
     } else if (key === "," || key === "<") {
-      soundSpeedProperty.value = Math.max(1.0, soundSpeedProperty.value - 1.0);
+      soundSpeedProperty.value = clamp(soundSpeedProperty.value - 1.0, soundSpeedRange);
     }
   }
 }

--- a/src/doppler-effect/view/utils/Sound.ts
+++ b/src/doppler-effect/view/utils/Sound.ts
@@ -29,7 +29,7 @@ export class Sound {
   private audioContext: AudioContext | null = null;
   private useGeneratedSound: boolean;
 
-  constructor(src: string, useGeneratedSound: boolean = false) {
+  constructor(src: string = "", useGeneratedSound: boolean = false) {
     this.useGeneratedSound = useGeneratedSound;
 
     if (!useGeneratedSound) {

--- a/tests/WaveGenerator.test.ts
+++ b/tests/WaveGenerator.test.ts
@@ -84,6 +84,26 @@ describe("WaveGenerator.generateWaves", () => {
     generator.reset();
     expect(waves.length).toBe(0);
   });
+
+  it("emits every elapsed interval when a single frame spans several intervals", () => {
+    // A 0.55 s frame at 10 Hz (0.1 s interval) covers 5 whole intervals.
+    time = 0.55;
+    generator.generateWaves();
+    expect(waves.length).toBe(5);
+  });
+
+  it("keeps a drift-free cadence across many small frames", () => {
+    // Advance in ~60 fps steps for 5 s; at 10 Hz we expect ~50 waves, and the
+    // emission clock must not lag behind by more than one interval.
+    const steps = Math.round(5 / (1 / 60));
+    for (let i = 1; i <= steps; i++) {
+      time = i / 60;
+      generator.generateWaves();
+    }
+    // 5 s at 10 Hz -> 50 intervals; allow a one-wave boundary tolerance.
+    expect(waves.length).toBeGreaterThanOrEqual(49);
+    expect(waves.length).toBeLessThanOrEqual(50);
+  });
 });
 
 describe("WaveGenerator.detectWaveAt", () => {


### PR DESCRIPTION
Correctness:
- DragHandlerManager: reassign the clamped velocity. normalize() mutates in
  place while timesScalar() returns a new vector, so the previous code
  collapsed fast drags to a unit vector instead of clamping to max speed.
- Play the wave-detection click only from MicrophoneNode. The screen view
  listened to the same waveDetectedProperty and doubled the click.
- KeyboardHandlerManager: drop the inert Node input listener (wrong shape,
  never fired) and make the global keydown listener idempotent and removable
  (detachKeyboardHandlers) so it can't stack or leak; ignore keys while an
  editable control is focused.
- Reserve "s" for selecting the source; downward movement uses ArrowDown so
  the key no longer selects and moves at the same time.
- Clamp keyboard frequency/sound-speed adjustments to the model ranges the
  sliders enforce.

Model:
- WaveGenerator: advance the emission clock by whole intervals so the wave
  cadence is drift-free and frames spanning multiple intervals emit each wave.
- Document the time-reversal radius reconstruction (exact under constant sound
  speed) and clamp it to be non-negative.

Cleanup:
- Microphone drag bounds follow the visible model area instead of a static
  snapshot of the initial layout bounds.
- Fix baseColorProperty typo; make Sound's src optional and stop passing a
  dead audio path for the synthesized click.
- Bump biome.json schema to match the CLI (2.5.4).
- Add WaveGenerator cadence regression tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XjdfNKEvvJPi5CJnZMkrCo